### PR TITLE
Add user only for admin

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -11,7 +11,7 @@
     <%# end %>
     <% if current_page?(commitments_path) || current_page?(suppliers_path) %>
       <%= link_to "+ Ajouter en-cours", new_commitment_path, class: "btn-primary-bubo-commitment" %>
-    <% elsif current_page?(users_path) %>
+    <% elsif current_page?(users_path) && current_user.admin? %>
       <%=  link_to "+ Ajouter une personne", new_organization_user_path(current_user.organization), class: "btn-primary-bubo-commitment" %>
     <% else %>
       <% if user_signed_in? %>


### PR DESCRIPTION
authorize only admin users to add a new organization's user

basic method used :
if current_user.admin?

Other options + pundit to be explored
https://github.com/plataformatec/devise/wiki/How-To:-Add-an-Admin-Role